### PR TITLE
Feature Request: Allow validating properties of object in a request

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ router.post('/users', validate({
      ...
   }
 )
+
+// With nested object
+router.post('/users', validate({
+    'bio.name': ['require', 'Name is required'],
+    'bio.age': ['require', 'isInt', 'Age must be a number']
+  }), function *(next) {
+    ...
+  }
+)
 ```
 
 ### Usage

--- a/src/index.js
+++ b/src/index.js
@@ -82,19 +82,13 @@ export default function validate(rules) {
   }
 
   function getValueByPath(obj, path) {
-    return !!~path.indexOf(".")
-            ? path
-              .split(".")
-              .reduce(
-                (element, property) =>
-                  isObject(element) ? element[property] : undefined,
-                obj
-              )
-            : obj[path];
+    return path.indexOf('.') === -1
+            ? obj[path]
+            : path.split('.').reduce((res, prop) => isObject(res) && res[prop], obj)
   }
 
   function isObject(obj) {
-    return typeof obj === 'object' && obj !== null && !Array.isArray(obj)
+    return Object.prototype.toString.call(obj) === '[object Object]'
   }
 
   function isNullOrEmpty(str) {

--- a/src/index.js
+++ b/src/index.js
@@ -70,15 +70,23 @@ export default function validate(rules) {
       }
 
       const value = scope === 'params'
-        ? ctx.params[name]
+        ? getValueByPath(ctx.params, name)
         : scope === 'query'
-          ? ctx.request.query[name]
-          : (ctx.request.body && ctx.request.body[name])
+          ? getValueByPath(ctx.request.query, name)
+          : (ctx.request.body && getValueByPath(ctx.request.body, name))
 
       if (value != null) {
         return value
       }
     }
+  }
+
+  function getValueByPath(obj, path) {
+    return path.split('.').reduce((ele, p) => isObject(ele) ? ele[p] : ele, obj)
+  }
+
+  function isObject(obj) {
+    return typeof obj === 'object' && obj !== null && !Array.isArray(obj)
   }
 
   function isNullOrEmpty(str) {

--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,15 @@ export default function validate(rules) {
   }
 
   function getValueByPath(obj, path) {
-    return path.split('.').reduce((ele, p) => isObject(ele) ? ele[p] : ele, obj)
+    return !!~path.indexOf(".")
+            ? path
+              .split(".")
+              .reduce(
+                (element, property) =>
+                  isObject(element) ? element[property] : undefined,
+                obj
+              )
+            : obj[path];
   }
 
   function isObject(obj) {

--- a/test/index.js
+++ b/test/index.js
@@ -77,4 +77,57 @@ describe('validate', () => {
       assert.equal(err.message, 'message1')
     }
   })
+
+  it('should invoke checks with correct path', async () => {
+    const mock = sinon.mock(validator)
+    mock.expects('check1').withArgs('value').once().returns(true)
+    mock.expects('check2').withArgs('value', 1, '2').once().returns(true)
+
+    const middleware = validate({
+      'field.nested': ['check1', 'check2(1, "2")', 'message']
+    })
+
+    await middleware.call(createContext({
+      params: {
+        field: {nested: 'value'}
+      }
+    })).next()
+    mock.verify()
+  })
+
+  it('should throw error if value of object params is invalid ', async () => {
+    const middleware = validate({
+      'field.nested': ['require', 'message']
+    })
+    try {
+       await middleware.call(createContext({
+        params: {
+          field: {nested: null}
+        }
+      })).next()
+
+      assert.fail()
+    } catch (err) {
+      assert.equal(err.message, 'message')
+      assert.equal(err.status, 400)
+    }
+  })
+
+  it('should search only in the specified scopes with obj param', async () => {
+    const middleware = validate({
+      'field.nested:query:params': ['require', 'message1']
+    })
+
+    try {
+      await middleware.call(createContext({
+        body: {
+          field: {nested: 'value'}
+        }
+      })).next()
+      assert.fail()
+    }
+    catch (err) {
+      assert.equal(err.message, 'message1')
+    }
+  })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -78,56 +78,28 @@ describe('validate', () => {
     }
   })
 
-  it('should invoke checks with correct path', async () => {
+  it('should invoke checks for nested path', async () => {
     const mock = sinon.mock(validator)
-    mock.expects('check1').withArgs('value').once().returns(true)
-    mock.expects('check2').withArgs('value', 1, '2').once().returns(true)
+    mock.expects('check1').withArgs('value').twice().returns(true)
+    mock.expects('check2').withArgs('value', 1, '2').twice().returns(true)
 
     const middleware = validate({
-      'field.nested': ['check1', 'check2(1, "2")', 'message']
+      'field1.level1': ['check1', 'check2(1, "2")', 'message1'],
+      'field2.level1.level2': ['check1', 'check2(1, "2")', 'message2']
     })
 
     await middleware.call(createContext({
       params: {
-        field: {nested: 'value'}
+        field1: {
+          level1: 'value'
+        },
+        field2: {
+          level1: {
+            level2: 'value'
+          }
+        }
       }
     })).next()
     mock.verify()
-  })
-
-  it('should throw error if value of object params is invalid ', async () => {
-    const middleware = validate({
-      'field.nested': ['require', 'message']
-    })
-    try {
-       await middleware.call(createContext({
-        params: {
-          field: {nested: null}
-        }
-      })).next()
-
-      assert.fail()
-    } catch (err) {
-      assert.equal(err.message, 'message')
-      assert.equal(err.status, 400)
-    }
-  })
-
-  it('should search only in the specified scopes with obj param', async () => {
-    const middleware = validate({
-      'field.nested:query:params': ['require', 'message1']
-    })
-
-    try {
-      await middleware.call(createContext({
-        body: {
-          field: {nested: 'value'}
-        }
-      })).next()
-      assert.fail()
-    }
-    catch (err) {
-      assert.equal(err.message, 'message1')
-    }
   })
 })


### PR DESCRIPTION
Validating properties of a object or a nested object in a request is necessary in some use cases. It would be better if the `validate` middleware has these capability. I propose a conventional syntax for validating object's properties.

If the proposal is approved, I am willing to update the README. 