### PR TITLE
[Proposal] Supporting async validators

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015-node4"]
+  "presets": ["es2015-node4"],
+  "plugins": ["transform-async-to-generator"]
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babel": "^6.3.26",
     "babel-cli": "^6.3.17",
     "babel-plugin-syntax-async-functions": "^6.3.13",
+    "babel-plugin-transform-async-to-generator": "^6.24.1",
     "babel-plugin-transform-regenerator": "^6.3.26",
     "babel-polyfill": "^6.3.14",
     "babel-preset-es2015-node4": "^2.0.2",

--- a/test/index.js
+++ b/test/index.js
@@ -31,11 +31,11 @@ describe('validate', () => {
       field: ['check1', 'check2(1, "2")', 'message']
     })
 
-    await middleware.call(createContext({
+    await middleware(createContext({
       params: {
         field: 'value'
       }
-    })).next()
+    }))
     mock.verify()
   })
 
@@ -47,7 +47,7 @@ describe('validate', () => {
     })
 
     try {
-      await middleware.call(createContext({
+      await middleware(createContext({
         body: {
           field1: null,
           field2: '',
@@ -55,7 +55,7 @@ describe('validate', () => {
             level1: null
           }
         }
-      })).next()
+      }))
       assert.fail()
     }
     catch (err) {
@@ -70,11 +70,11 @@ describe('validate', () => {
     })
 
     try {
-      await middleware.call(createContext({
+      await middleware(createContext({
         body: {
           field1: 'value'
         }
-      })).next()
+      }))
       assert.fail()
     }
     catch (err) {
@@ -92,7 +92,7 @@ describe('validate', () => {
       'field2.level1.level2': ['check1', 'check2(1, "2")', 'message2']
     })
 
-    await middleware.call(createContext({
+    await middleware(createContext({
       params: {
         field1: {
           level1: 'value'
@@ -103,7 +103,7 @@ describe('validate', () => {
           }
         }
       }
-    })).next()
+    }))
     mock.verify()
   })
 })


### PR DESCRIPTION
- Change generator function into async function to support Koa v2
- Allowing async validators to work just like sync validators

Hi, @buunguyen !
There are some use cases I would like to have an async validator (such as checking an email exist). This PR is a naive implementation which is served as a proposal. I'm looking forward hearing from your feedbacks and suggestions.