### PR TITLE
Support searching in header scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ __Options__
 
 `opts` is an object specifying the fields and their corresponding validation rules.
 
-* Each key is a field name in the post data (e.g. 'name', 'user.name') with optional search scopes: `header`, `headers`, `query`, `body` and `params`. Field name and scopes are separated by `:`. If no scope is specified, all scopes are searched.
+* Each key is a field name in the post data (e.g. 'name', 'user.name') with optional search scopes: `header` (alias `headers`), `query`, `body` and `params`. Field name and scopes are separated by `:`. If no scope is specified, all scopes are searched.
 
 * Value is a rule array with the final element being an error message. A rule can be any of the [supported methods](https://github.com/chriso/validator.js#validators) of node-validator or a custom sync/async validator `fn(value, ...args)`. Arguments can be provided, but make sure the omit the `str` argument (the first one) as it is automatically supplied by the middleware.
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ If a field has no value, it won't be validated. To make a field required, add th
 __Examples__
 
 ```js
+import validator from 'validator'
+
+// add custom validator
+validator['isUserNameNew'] = async (username) => await db.Users.isNew(username)
+
 validate({
   // Only find and validate email from request.body
   'email:body': ['require', 'isEmail', 'Invalid email address'],
@@ -61,10 +66,6 @@ validate({
   // Check user name exist
   'username': ['isUserNameNew', 'Username already exists']
 })
-
-async function isUserNameNew(username) {
-    return await db.Users.isNew(username) // return a Promise
-}
 ```
 
 __Route decorators__

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ __Options__
 
 `opts` is an object specifying the fields and their corresponding validation rules.
 
-* Each key is a field name in the post data (e.g. 'name', 'user.name') with optional search scopes: `query`, `body` and `params`. Field name and scopes are separated by `:`. If no scope is specified, all scopes are searched.
+* Each key is a field name in the post data (e.g. 'name', 'user.name') with optional search scopes: `header`, `headers`, `query`, `body` and `params`. Field name and scopes are separated by `:`. If no scope is specified, all scopes are searched.
 
 * Value is a rule array with the final element being an error message. A rule can be any of the [supported methods](https://github.com/chriso/validator.js#validators) of node-validator or a custom sync/async validator `fn(value, ...args)`. Arguments can be provided, but make sure the omit the `str` argument (the first one) as it is automatically supplied by the middleware.
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import validator from 'validator'
 
 const FN_REGEXP = /(.*)\((.*)\)/
 const ARGS_REGEXP = /(?:[^,"']+|"[^"]*?"|'[^']*?')+/g
-const SCOPES = ['params', 'query', 'body']
+const SCOPES = ['params', 'query', 'body', 'header', 'headers']
 
 export default function validate(rules) {
   return async (ctx, next) => {
@@ -72,8 +72,7 @@ export default function validate(rules) {
 
       const value = scope === 'params'
         ? getValueByPath(ctx.params, name)
-        : scope === 'query'
-          ? getValueByPath(ctx.request.query, name)
+        : ctx.request[`${scope}`] ? getValueByPath(ctx.request[`${scope}`], name)
           : (ctx.request.body && getValueByPath(ctx.request.body, name))
 
       if (value != null) {

--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ export default function validate(rules) {
   }
 
   function getFieldValue(ctx, field) {
-    let [name, ...scopes] = field.split(':')
+    let [path, ...scopes] = field.split(':')
 
     if (scopes.length === 0) {
       scopes = SCOPES
@@ -70,10 +70,9 @@ export default function validate(rules) {
         throw new Error(`Invalid scope, must be one of ${SCOPES.join(', ')}`)
       }
 
-      const value = scope === 'params'
-        ? getValueByPath(ctx.params, name)
-        : ctx.request[`${scope}`] ? getValueByPath(ctx.request[`${scope}`], name)
-          : (ctx.request.body && getValueByPath(ctx.request.body, name))
+      const data = ctx[scope] || ctx.request[scope]
+
+      const value = getValueAtPath(data, path)
 
       if (value != null) {
         return value
@@ -81,7 +80,7 @@ export default function validate(rules) {
     }
   }
 
-  function getValueByPath(obj, path) {
+  function getValueAtPath(obj, path) {
     return path.indexOf('.') === -1
             ? obj[path]
             : path.split('.').reduce((res, prop) => isObject(res) ? res[prop] : undefined, obj)

--- a/test/index.js
+++ b/test/index.js
@@ -13,10 +13,10 @@ describe('validate', () => {
   }
 
   const validate = proxyquire('../src', {validator}).default
-  const createContext = ({query = {}, body = {}, params = {}}) => {
+  const createContext = ({query = {}, body = {}, params = {}, header = {}, headers = {}}) => {
     return {
       params,
-      request: {query, body},
+      request: {query, body, header, headers},
       throw(msg, status) {
         const error = new Error(msg)
         error.status = status
@@ -41,7 +41,7 @@ describe('validate', () => {
     }))
     mock.verify()
   })
-  
+
   it('should deal with regexp separator', async () => {
     const mock = sinon.mock(validator)
     mock.expects('check1').withArgs('value', 1, '^[a-z]{0,6}$', '3', 4).once().returns(true)
@@ -51,7 +51,6 @@ describe('validate', () => {
     await middleware(createContext({params: {field: 'value'}}))
     mock.verify()
   })
-  
 
   it('should invoke checks for nested path', async () => {
     const mock = sinon.mock(validator)
@@ -128,7 +127,7 @@ describe('validate', () => {
 
   it('should search only in the specified scopes', async () => {
     const middleware = validate({
-      'field1:query:params': ['require', 'message1']
+      'field1:query:params:header:headers': ['require', 'message1']
     })
 
     try {


### PR DESCRIPTION
Allowing the validator to search in the header request ( headers as alias ).
cc @buunguyen 