### PR TITLE
Add option to disable searching scopes by colon separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ __Options__
 
 If a field has no value, it won't be validated. To make a field required, add the special `required` rule (or its alias `isRequired`). If there are validation failures, the middleware invokes `ctx.throw()` with status code `400` and all error messages.
 
-`opts` is an object specifying the options. By default, `opts = {}`. At this time we support one option:
+`opts` is an object specifying the options. At this time we support one option, by default it is:
 ```js
-opts = {searchScopeDisabled: true}
+opts = {searchScopeEnabled: true}
 ```
-This will ignore to search scopes that are separated by the `:` separator. The field name will contain `:` and all scopes will be searched.
+If `searchScopeEnabled` set to `false`, it will ignore to search scopes that are separated by the `:` separator. The field name will contain `:` and all scopes will be searched.
 
 __Examples__
 
@@ -81,7 +81,7 @@ validate({
 validate({
   // Find appium:deviceName from all scopes
   'appium:deviceName': ['require', 'Invalid device name']
-}, {searchScopeDisabled: true})
+}, {searchScopeEnabled: false})
 ```
 
 __Route decorators__

--- a/README.md
+++ b/README.md
@@ -32,18 +32,24 @@ __Basic__
 ```js
 import validate from 'koa-req-validator'
 
-router.post(path, validate(opts), ...)
+router.post(path, validate(rules, opts), ...)
 ```
 
 __Options__
 
-`opts` is an object specifying the fields and their validation rules.
+`rules` is an object specifying the fields and their validation rules.
 
 * Each key is a field name in the post data (e.g. 'name', 'user.name') with optional search scopes: `header` (alias `headers`), `query`, `body` and `params`. Field name and scopes are separated by `:`. If no scope is specified, **all** scopes are searched.
 
 * Value is a rule array with the last element being an error message. A rule can be any of the [supported methods](https://github.com/chriso/validator.js#validators) of node-validator or a custom validator `function(value: *, ...args: Array<*>, ctx: KoaContext): Promise<boolean>|boolean`. `value` is the value to be validated from one of the scopes. `args` are additional arguments that can be declared for the validator (see the `isLength` example above). `ctx` is the [Koa context](https://github.com/koajs/koa/blob/master/docs/api/context.md).
 
 If a field has no value, it won't be validated. To make a field required, add the special `required` rule (or its alias `isRequired`). If there are validation failures, the middleware invokes `ctx.throw()` with status code `400` and all error messages.
+
+`opts` is an object specifying the options. By default, `opts = {}`. At this time we support one option:
+```js
+opts = {searchScopeDisabled: true}
+```
+This will ignore to search scopes that are separated by the `:` separator. The field name will contain `:` and all scopes will be searched.
 
 __Examples__
 
@@ -71,6 +77,11 @@ validate({
   // Find username in all scopes
   'username': ['validateUserName("devs")', 'Invalid username'],
 })
+
+validate({
+  // Find appium:deviceName from all scopes
+  'appium:deviceName': ['require', 'Invalid device name']
+}, {searchScopeDisabled: true})
 ```
 
 __Route decorators__
@@ -84,7 +95,7 @@ import bodyParser from 'koa-bodyparser'
 @controller('/users', convert(bodyParser()))
 export default class extends Ctrl {
 
-  @post('', validate(opts))
+  @post('', validate(rules))
   async register(ctx, next) {
     ...
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-req-validator",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Koa middleware to validate request parameters",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -5,12 +5,15 @@ const ARGS_REGEXP = /(?:[^,"']+|"[^"]*?"|'[^']*?')+/g
 const SCOPES = ['params', 'query', 'body', 'header', 'headers']
 
 export default function validate(rules, opts = {}) {
+  const defaultOpts = {searchScopeEnabled: true}
+  const optWithDefault = Object.assign(defaultOpts, opts)
+
   return async (ctx, next) => {
     const errors = []
 
     for (let field of Object.keys(rules)) {
       const fieldRules = rules[field]
-      const fieldValue = getFieldValue(ctx, field, opts)
+      const fieldValue = getFieldValue(ctx, field, optWithDefault)
       const message = fieldRules[fieldRules.length - 1]
       const checks = fieldRules.slice(0, -1)
 
@@ -62,8 +65,8 @@ export default function validate(rules, opts = {}) {
   }
 
   function getFieldValue(ctx, field, opts = {}) {
-    const {searchScopeDisabled} = opts
-    let [path, ...scopes] = searchScopeDisabled ? [field] : field.split(':')
+    const {searchScopeEnabled} = opts
+    let [path, ...scopes] = searchScopeEnabled ? field.split(':') : [field]
 
     if (scopes.length === 0) {
       scopes = SCOPES

--- a/src/index.js
+++ b/src/index.js
@@ -4,13 +4,13 @@ const FN_REGEXP = /(.*)\((.*)\)/
 const ARGS_REGEXP = /(?:[^,"']+|"[^"]*?"|'[^']*?')+/g
 const SCOPES = ['params', 'query', 'body', 'header', 'headers']
 
-export default function validate(rules) {
+export default function validate(rules, opts = {}) {
   return async (ctx, next) => {
     const errors = []
 
     for (let field of Object.keys(rules)) {
       const fieldRules = rules[field]
-      const fieldValue = getFieldValue(ctx, field)
+      const fieldValue = getFieldValue(ctx, field, opts)
       const message = fieldRules[fieldRules.length - 1]
       const checks = fieldRules.slice(0, -1)
 
@@ -61,8 +61,9 @@ export default function validate(rules) {
     return await validator[check](...args)
   }
 
-  function getFieldValue(ctx, field) {
-    let [path, ...scopes] = field.split(':')
+  function getFieldValue(ctx, field, opts = {}) {
+    const {searchScopeDisabled} = opts
+    let [path, ...scopes] = searchScopeDisabled ? [field] : field.split(':')
 
     if (scopes.length === 0) {
       scopes = SCOPES

--- a/test/index.js
+++ b/test/index.js
@@ -146,7 +146,7 @@ describe('validate', () => {
   it('should disable searching the scopes by colon separator', async () => {
     const middleware = validate({
       'prefix:field': ['require', 'message1'],
-    }, {searchScopeDisabled: true})
+    }, {searchScopeEnabled: false})
 
     try {
       await middleware(createContext({

--- a/test/index.js
+++ b/test/index.js
@@ -143,6 +143,25 @@ describe('validate', () => {
     }
   })
 
+  it('should disable searching the scopes by colon separator', async () => {
+    const middleware = validate({
+      'prefix:field': ['require', 'message1'],
+    }, {searchScopeDisabled: true})
+
+    try {
+      await middleware(createContext({
+        body: {
+          'prefix': 'value1',
+          'prefix:field': null
+        }
+      }))
+      assert.fail()
+    }
+    catch (err) {
+      assert.equal(err.message, 'message1')
+    }
+  })
+
   it('should transfer the koa context at last parameter', async () => {
     let koaContext = createContext({
       params: {


### PR DESCRIPTION
Hi @buunguyen, cc @duylam, @ledinhphuong
There are some situations that we need to search the field value that contains the `:` character. For example with this request body:
```
body = {
  "appium:deviceName": "Galaxy S7",
  "appium:platformVersion": "7.0"
}
```
As we have been split the scopes and field by the `:` then it will throw an error with the above scenario. So I think it's necessary to have an option to disable to search the scopes by `:` and let the field value as it is. 